### PR TITLE
Remove clause that is contradicted by section 8.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,8 +323,7 @@ UNSW CSESoc's Constitution; Easily track changes and see who suggested what amen
         have a casting vote in the election. 
     8.6 Upon finalising of the election results, they must be pronounced to the membership within 
         one (1) business day. 
-    8.7 Only full members are entitled to vote for the Executive. Full members may vote for two 
-        (2) candidates for Co-president, and one (1) candidate for each other position. 
+    8.7 Only full members are entitled to vote for the Executive.    
     8.8 Voting is to be confidential and anonymous with the exception of,
         8.8.1 In the event of a full member being prevented by the School of CSE from accessing the voting site,
         votes shall be submitted to the first executive member not running in the election in the following list; 


### PR DESCRIPTION
Section 8.9 states that elections will use a single transferable vote system, which involves giving preferences to candidates. 

"Full members may vote for two (2) candidates for Co-president, and one (1) candidate for each other position." Is inconsistent with this.