### PR TITLE
Remove nomination opening restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ UNSW CSESoc's Constitution; Easily track changes and see who suggested what amen
 
 # 8 ELECTIONS 
 
-    8.1 Nominations for the Executive positions shall open at the AGM. 
+    8.1 Nominations for the Executive positions shall open during Arc-affiliated club's election period.
     8.2 Nominations must remain open until the later of: 
         8.2.1 one calendar week after nominations open; or 
         8.2.2 there are at least two (2) nominees for Co-presidents and one (1) nominee for each 


### PR DESCRIPTION
Arc regulation which stipulates that "The Club must hold an AGM or EGM on the next academic day after the voting ends to announce the results of the election."

This change will allow future executives to run elections prior to the AGM, removing the need to run an extra EGM afterwards.