### PR TITLE
Reduce required election time

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,8 @@ UNSW CSESoc's Constitution; Easily track changes and see who suggested what amen
         8.4.1 Only elections run by the School of CSE shall be recognised. 
         8.4.2 The Exec may choose that the list be made publicly available during the nomination 
               period. If they choose to do so, it must be on the Society website. 
-        8.4.3 The election will run for at least one calendar week. 
+        8.4.3 The election will run for at least three academic days.
+        8.4.4 The election must be advertised three weeks prior to the commencement date and be advertised through the society news letter and Facebook.
     8.5 If there is a tie for any Executive position between candidates, the outgoing executives shall 
         have a casting vote in the election. 
     8.6 Upon finalising of the election results, they must be pronounced to the membership within 


### PR DESCRIPTION
The election period is a stressful time for candidates. The week long election period increases the amount of campaigning required by candidates and the period with which they must be anxious about the election without much gain. Three days is adequate time for members to discern the candidates they wish to vote for and to vote. To further ensure everyone who wishes to vote hears about the election, clause 8.4.4  stipulates that the election should be properly advertised.